### PR TITLE
MeterialMenuButton: OnMenuSelected raises when Popover closed and no menu selected

### DIFF
--- a/XF.Material/XF.Material.Forms/UI/MaterialMenuButton.cs
+++ b/XF.Material/XF.Material.Forms/UI/MaterialMenuButton.cs
@@ -124,7 +124,7 @@ namespace XF.Material.Forms.UI
         /// For internal use only.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public void OnViewTouch(double x, double y)
+        public virtual void OnViewTouch(double x, double y)
         {
             if (this.Choices == null || this.Choices?.Count == 0)
             {
@@ -146,6 +146,10 @@ namespace XF.Material.Forms.UI
                 if (result >= 0)
                 {
                     this.OnMenuSelected(new MaterialMenuResult(result, this.CommandParameter));
+                }
+             else
+                {
+                    this.OnMenuSelected(new MaterialMenuResult(-1, null));
                 }
             });
         }

--- a/XF.Material/XF.Material.Forms/UI/MaterialTextField.xaml.cs
+++ b/XF.Material/XF.Material.Forms/UI/MaterialTextField.xaml.cs
@@ -1182,7 +1182,10 @@ namespace XF.Material.Forms.UI
             }
             else
             {
-                result = await MaterialDialog.Instance.SelectChoiceAsync(title, _choices, confirmingText, dismissiveText, configuration);
+                if (_choices?.Count > 0)
+                    result = await MaterialDialog.Instance.SelectChoiceAsync(title, _choices, 0, confirmingText, dismissiveText, configuration);
+                else
+                    result = await MaterialDialog.Instance.SelectChoiceAsync(title, _choices, confirmingText, dismissiveText, configuration);
             }
 
             if (result >= 0)

--- a/XF.Material/XF.Material.iOS/Renderers/MaterialLabelRenderer.cs
+++ b/XF.Material/XF.Material.iOS/Renderers/MaterialLabelRenderer.cs
@@ -24,6 +24,7 @@ namespace XF.Material.iOS.Renderers
 
             this.CheckIfSingleLine();
             this.UpdateLetterSpacing(this.Control, this.Element.LetterSpacing);
+            EnsureLineBreakMode();
         }
 
         private void CheckIfSingleLine()
@@ -43,6 +44,35 @@ namespace XF.Material.iOS.Renderers
                 this.Element.LineHeight = 1;
             }
         }
+        private void EnsureLineBreakMode()
+        {
+            if (Element == null || Control == null)
+                return;
+            var lbm = Element.LineBreakMode;
+            switch (lbm)
+            {
+                case Xamarin.Forms.LineBreakMode.NoWrap:
+                    Control.LineBreakMode = UIKit.UILineBreakMode.Clip;
+                    break;
+                case Xamarin.Forms.LineBreakMode.WordWrap:
+                    Control.LineBreakMode = UIKit.UILineBreakMode.WordWrap;
+                    break;
+                case Xamarin.Forms.LineBreakMode.CharacterWrap:
+                    Control.LineBreakMode = UIKit.UILineBreakMode.CharacterWrap;
+                    break;
+                case Xamarin.Forms.LineBreakMode.HeadTruncation:
+                    Control.LineBreakMode = UIKit.UILineBreakMode.HeadTruncation;
+                    break;
+                case Xamarin.Forms.LineBreakMode.TailTruncation:
+                    Control.LineBreakMode = UIKit.UILineBreakMode.TailTruncation;
+                    break;
+                case Xamarin.Forms.LineBreakMode.MiddleTruncation:
+                    Control.LineBreakMode = UIKit.UILineBreakMode.MiddleTruncation;
+                    break;
+                default:
+                    break;
+            }
+        }
 
         protected override void OnElementChanged(ElementChangedEventArgs<Label> e)
         {
@@ -51,6 +81,7 @@ namespace XF.Material.iOS.Renderers
             if(e?.NewElement != null)
             {
                 this.UpdateLetterSpacing(this.Control, this.Element.LetterSpacing);
+                EnsureLineBreakMode();
             }
         }
 
@@ -64,6 +95,7 @@ namespace XF.Material.iOS.Renderers
                 case nameof(Label.Text):
                     UpdateLetterSpacing(this.Control, this.Element.LetterSpacing);
                     this.CheckIfSingleLine();
+                    EnsureLineBreakMode();
                     break;
             }
         }


### PR DESCRIPTION
Added possibility to track MeterialMenuButton's Popover closed without selection any menu item (user tap outside of the dialog)